### PR TITLE
Add defense-in-depth PII detection

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Pre-push hook: scan all tracked files for PII patterns before pushing.
+# Install via: ./scripts/install-hooks.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec "$REPO_ROOT/scripts/pii-check.sh" push

--- a/.github/workflows/vault-health.yml
+++ b/.github/workflows/vault-health.yml
@@ -1,5 +1,9 @@
 name: Vault Health
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: '0 9 * * 1'  # Weekly Monday 9am UTC
   workflow_dispatch:
@@ -9,6 +13,14 @@ permissions:
   issues: write
 
 jobs:
+  pii-scan:
+    name: PII Detection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan for PII patterns
+        run: ./scripts/pii-check.sh push
+
   frontmatter-lint:
     name: Validate Frontmatter
     runs-on: ubuntu-latest

--- a/.pii-allowlist
+++ b/.pii-allowlist
@@ -1,0 +1,10 @@
+# Files excluded from PII scanning (glob patterns, one per line)
+# These paths may intentionally contain PII-like examples or patterns.
+docs/examples/*
+scripts/pii-check.sh
+.pii-patterns
+.pii-allowlist
+# Hook source code references env vars like OPENAI_API_KEY (not actual secrets)
+hooks/core/*.ts
+hooks/providers/*/*.ts
+hooks/workers/*.ts

--- a/.pii-patterns
+++ b/.pii-patterns
@@ -1,0 +1,23 @@
+# PII Detection Patterns
+# One ERE (Extended Regular Expression) per line. Lines starting with # are comments.
+# Prefix a pattern with [i] for case-insensitive matching.
+#
+# POSIX ERE only — no PCRE (?i), \s, \d. Use [[:space:]], [0-9], grep -iE.
+
+# API keys and tokens (high-confidence, length-gated)
+sk-[A-Za-z0-9_-]{20,}
+ghp_[A-Za-z0-9]{20,}
+gho_[A-Za-z0-9]{20,}
+github_pat_[A-Za-z0-9_]{20,}
+
+# Secrets in assignments (case-insensitive)
+[i] (api[_-]?key|api[_-]?secret|password|passwd)[[:space:]]*[:=][[:space:]]*[^[:space:]"']{8,}
+
+# Home directory absolute paths
+/Users/[a-zA-Z0-9._-]+/
+/home/[a-zA-Z0-9._-]+/
+
+# === ADD YOUR OWN PATTERNS BELOW ===
+# your-github-username
+# your-real-name
+# your-work-org-name

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,23 @@ This vault is a **persistent knowledge base** that captures insights, decisions,
 **What goes here:** Durable knowledge, decisions, patterns, learnings, and session logs worth preserving.
 **What stays in PAI:** Active session state, auto-memory, working context, ephemeral notes.
 
+## PUBLIC REPOSITORY — No PII Allowed
+
+This is a **public template repository**. Every file committed here is visible to the internet.
+
+**Non-negotiable rules:**
+- NEVER commit real usernames, email addresses, or full names
+- NEVER commit real project names from work or personal repos
+- NEVER commit API keys, tokens, or secrets
+- NEVER commit absolute home directory paths (use `~` or generic paths)
+- Use generic examples: `acme-api`, `my-cli-tool`, `user@example.com`
+
+**Enforcement (2 layers):**
+1. **Pre-push hook** — scans all tracked files, blocks push to origin
+2. **CI workflow** — `pii-scan` job runs on every push/PR, catches bypasses
+
+No pre-commit hook (obsidian-git auto-commits would silently fail). Patterns are defined in `.pii-patterns`. Run `./scripts/install-hooks.sh` after cloning.
+
 ## Vault Conventions
 
 ### Frontmatter Schema

--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ A template repository for building a persistent knowledge base in [Obsidian](htt
    export OPENAI_API_KEY=sk-...          # or use Ollama (see below)
    ```
 
-4. **Run a session** — After your first AI coding session, check `Sessions/` for your first note.
+4. **Install PII detection hooks**
+   ```bash
+   ./scripts/install-hooks.sh
+   ```
+
+5. **Run a session** — After your first AI coding session, check `Sessions/` for your first note.
 
 ### Optional: Local LLM with Ollama
 

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -55,6 +55,14 @@ export OLLAMA_MODEL=llama3.1:8b
 - Claude: use wrapper scripts in `HOOKS.claude.md`.
 - Codex: use provider scripts in `HOOKS.codex.md`.
 
+## 3.5) Install PII detection hooks
+
+```bash
+./scripts/install-hooks.sh
+```
+
+This enables pre-push scanning for accidental PII leaks. Required for public repos.
+
 ## 4) Run a first test session
 
 Trigger one short coding session and let SessionEnd complete.

--- a/docs/session-intelligence/architecture.md
+++ b/docs/session-intelligence/architecture.md
@@ -67,7 +67,7 @@ Flow:
 | Transcript | `~/.claude/projects/{encoded-path}/{sessionId}.jsonl` | JSONL — message objects with `role`, `content`, `tool_use`, `tool_result` |
 | WORK tracking | `~/.claude/MEMORY/WORK/{dated-dir}/META.yaml` | YAML — session metadata, status, task count |
 
-**Encoded path:** Claude Code URL-encodes the project directory (e.g., `/Users/gregor/personal/cortana-obsidian` becomes `-Users-gregor-personal-cortana-obsidian`).
+**Encoded path:** Claude Code URL-encodes the project directory (e.g., `~/personal/my-vault` becomes `-Users-alice-personal-my-vault`).
 
 ### Claude Desktop
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install PII detection git hooks for this repository.
+# Sets core.hooksPath to .githooks/ (tracked in repo).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+existing=$(git config --local core.hooksPath 2>/dev/null || true)
+if [ -n "$existing" ] && [ "$existing" != ".githooks" ]; then
+  echo "WARNING: core.hooksPath is already set to '$existing'"
+  echo "This will be overridden. Press Ctrl+C to abort, Enter to continue."
+  read -r
+fi
+
+git config --local core.hooksPath .githooks
+chmod +x .githooks/*
+echo "PII detection hooks installed. Active on push."

--- a/scripts/pii-check.sh
+++ b/scripts/pii-check.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# PII Detection Script
+# Scans tracked files for patterns that indicate personally identifiable information.
+# Used by pre-push hook and CI.
+#
+# Usage:
+#   ./scripts/pii-check.sh staged   # scan staged files (for pre-commit)
+#   ./scripts/pii-check.sh push     # scan all tracked files (for pre-push / CI)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PATTERNS_FILE="$REPO_ROOT/.pii-patterns"
+ALLOWLIST_FILE="$REPO_ROOT/.pii-allowlist"
+
+MODE="${1:-push}"
+
+# --- Load allowlist ---
+ALLOWLIST_ARGS=()
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"          # strip comments
+    line="${line#"${line%%[![:space:]]*}"}" # trim leading whitespace
+    line="${line%"${line##*[![:space:]]}"}" # trim trailing whitespace
+    [ -z "$line" ] && continue
+    ALLOWLIST_ARGS+=("$line")
+  done < "$ALLOWLIST_FILE"
+fi
+
+is_allowlisted() {
+  local filepath="$1"
+  for pattern in "${ALLOWLIST_ARGS[@]+"${ALLOWLIST_ARGS[@]}"}"; do
+    # shellcheck disable=SC2254
+    case "$filepath" in
+      $pattern) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# --- Load patterns ---
+if [ ! -f "$PATTERNS_FILE" ]; then
+  echo "No .pii-patterns file found at $PATTERNS_FILE — skipping PII scan."
+  exit 0
+fi
+
+CASE_SENSITIVE_PATTERNS=()
+CASE_INSENSITIVE_PATTERNS=()
+
+while IFS= read -r line; do
+  line="${line%%#*}"          # strip inline comments
+  line="${line#"${line%%[![:space:]]*}"}" # trim leading whitespace
+  line="${line%"${line##*[![:space:]]}"}" # trim trailing whitespace
+  [ -z "$line" ] && continue
+
+  # [i] prefix means case-insensitive
+  if [[ "$line" == "[i] "* ]]; then
+    CASE_INSENSITIVE_PATTERNS+=("${line#\[i\] }")
+  else
+    CASE_SENSITIVE_PATTERNS+=("$line")
+  fi
+done < "$PATTERNS_FILE"
+
+if [ ${#CASE_SENSITIVE_PATTERNS[@]} -eq 0 ] && [ ${#CASE_INSENSITIVE_PATTERNS[@]} -eq 0 ]; then
+  echo "No patterns found in $PATTERNS_FILE — skipping PII scan."
+  exit 0
+fi
+
+# --- Get file list ---
+get_files() {
+  case "$MODE" in
+    staged)
+      git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACM
+      ;;
+    push)
+      git -C "$REPO_ROOT" ls-files
+      ;;
+    *)
+      echo "Unknown mode: $MODE (use 'staged' or 'push')" >&2
+      exit 2
+      ;;
+  esac
+}
+
+# --- Scan ---
+violations=0
+
+while IFS= read -r filepath; do
+  [ -z "$filepath" ] && continue
+
+  # Skip binary files
+  if file "$REPO_ROOT/$filepath" | grep -q "binary"; then
+    continue
+  fi
+
+  # Skip allowlisted paths
+  if is_allowlisted "$filepath"; then
+    continue
+  fi
+
+  # Case-sensitive patterns
+  for pattern in "${CASE_SENSITIVE_PATTERNS[@]+"${CASE_SENSITIVE_PATTERNS[@]}"}"; do
+    matches=$(grep -nE "$pattern" "$REPO_ROOT/$filepath" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+      while IFS= read -r match_line; do
+        line_num="${match_line%%:*}"
+        content="${match_line#*:}"
+        echo "PII DETECTED: $filepath:$line_num"
+        echo "  Pattern: $pattern"
+        echo "  Content: $content"
+        echo ""
+        violations=$((violations + 1))
+      done <<< "$matches"
+    fi
+  done
+
+  # Case-insensitive patterns
+  for pattern in "${CASE_INSENSITIVE_PATTERNS[@]+"${CASE_INSENSITIVE_PATTERNS[@]}"}"; do
+    matches=$(grep -niE "$pattern" "$REPO_ROOT/$filepath" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+      while IFS= read -r match_line; do
+        line_num="${match_line%%:*}"
+        content="${match_line#*:}"
+        echo "PII DETECTED: $filepath:$line_num"
+        echo "  Pattern (case-insensitive): $pattern"
+        echo "  Content: $content"
+        echo ""
+        violations=$((violations + 1))
+      done <<< "$matches"
+    fi
+  done
+
+done < <(get_files)
+
+if [ "$violations" -gt 0 ]; then
+  echo "========================================="
+  echo "BLOCKED: $violations PII pattern match(es) found."
+  echo "Fix the violations above, or add false positives to .pii-allowlist."
+  echo "========================================="
+  exit 1
+fi
+
+echo "PII scan passed — no matches found."
+exit 0


### PR DESCRIPTION
## Summary
- Add pre-push git hook + CI job to scan for PII patterns before code reaches origin
- No pre-commit hook (avoids breaking obsidian-git auto-commits)
- Patterns defined in `.pii-patterns` (POSIX ERE), allowlist in `.pii-allowlist`
- Sanitized remaining real username in `docs/session-intelligence/architecture.md`
- Updated `CLAUDE.md`, `README.md`, `START_HERE.md` with public repo policy and setup steps

## Test plan
- [x] `./scripts/pii-check.sh push` passes on clean repo
- [x] `./scripts/install-hooks.sh` installs without warnings
- [x] Staged file with `/Users/testuser/code` correctly blocked
- [ ] CI `pii-scan` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)